### PR TITLE
Patch trv allele imputation

### DIFF
--- a/src/libtcrlm/schema/tcr.py
+++ b/src/libtcrlm/schema/tcr.py
@@ -84,7 +84,7 @@ class Tcrv:
 
     def _assume_first_functional_allele(self) -> None:
         alleles = tt.tr.query(
-            contains_pattern=self.gene, precision="allele", functionality="F"
+            contains_pattern=self.gene.name, precision="allele", functionality="F"
         )
 
         if len(alleles) == 0:

--- a/tests/test_schema/test_tcr.py
+++ b/tests/test_schema/test_tcr.py
@@ -1,5 +1,4 @@
 import pytest
-
 from libtcrlm import schema
 
 
@@ -85,3 +84,9 @@ def test_repr(mock_tcr):
 def test_equality(anchor, comparison, expected):
     result = anchor == comparison
     assert result == expected
+
+
+def test_allele_imputation():
+    tcr = schema.make_tcr_from_components("TRAV1-1", "CATQYF", "TRBV12-2", "CASQYF")
+    assert tcr._trav.allele_num == 1
+    assert tcr._trbv.allele_num == 2


### PR DESCRIPTION
- Allele imputation bug reported by @guillametlucia where TRBV12-2 is imputed to TRBV12-2*01
- However 12-2*01 is a pseudogene (12-2*02 is the first functional allele)
- Allele imputation improved to intelligently pick first functional allele