### PR TITLE
Fix musmusculus support

### DIFF
--- a/src/libtcrlm/schema/tcr.py
+++ b/src/libtcrlm/schema/tcr.py
@@ -13,7 +13,9 @@ def setup(species: Literal["homosapiens", "musmusculus"] = "homosapiens"):
             f'the only two supported species are currently "homosapiens" or "musmusculus" (received: "{species}")'
         )
 
-    global TravGene, TrbvGene
+    global SPECIES, TravGene, TrbvGene
+
+    SPECIES = species
 
     def get_v_gene_indices(gene_symbol):
         match = re.match(r"TR[AB]V([0-9]+)(-([0-9]+))?", gene_symbol)
@@ -58,7 +60,7 @@ class Tcrv:
             return None
 
         allele_symbol = self.__repr__()
-        cdr1 = tt.tr.get_aa_sequence(allele_symbol)["CDR1-IMGT"]
+        cdr1 = tt.tr.get_aa_sequence(allele_symbol, species=SPECIES)["CDR1-IMGT"]
         return cdr1
 
     @property
@@ -67,7 +69,7 @@ class Tcrv:
             return None
 
         allele_symbol = self.__repr__()
-        aa_sequence_dictionary = tt.tr.get_aa_sequence(allele_symbol)
+        aa_sequence_dictionary = tt.tr.get_aa_sequence(allele_symbol, species=SPECIES)
 
         if "CDR2-IMGT" not in aa_sequence_dictionary:
             return ""

--- a/tests/test_schema/test_tcr.py
+++ b/tests/test_schema/test_tcr.py
@@ -99,12 +99,12 @@ class TestSetup:
         tcr = schema.make_tcr_from_components(
             "TRAV1-1*01", "CATQYF", "TRBV2*01", "CASQYF"
         )
-        tcr.cdr1a_sequence == "TSGFYG"
-        tcr.cdr2a_sequence == "NALDGL"
-        tcr.junction_a_sequence == "CATQYF"
-        tcr.cdr1b_sequence == "SNHLY"
-        tcr.cdr2b_sequence == "FYNNEI"
-        tcr.junction_b_sequence == "CASQYF"
+        assert tcr.cdr1a_sequence == "TSGFYG"
+        assert tcr.cdr2a_sequence == "NALDGL"
+        assert tcr.junction_a_sequence == "CATQYF"
+        assert tcr.cdr1b_sequence == "SNHLY"
+        assert tcr.cdr2b_sequence == "FYNNEI"
+        assert tcr.junction_b_sequence == "CASQYF"
 
         with pytest.raises(exception.BadV):
             tcr = schema.make_tcr_from_components(
@@ -115,12 +115,12 @@ class TestSetup:
         tcr = schema.make_tcr_from_components(
             "TRAV1*01", "CATQYF", "TRBV1*01", "CASQYF"
         )
-        tcr.cdr1a_sequence == "TSGFYG"
-        tcr.cdr2a_sequence == "NALDGL"
-        tcr.junction_a_sequence == "CATQYF"
-        tcr.cdr1b_sequence == "SNHLY"
-        tcr.cdr2b_sequence == "FYNNEI"
-        tcr.junction_b_sequence == "CASQYF"
+        assert tcr.cdr1a_sequence == "TSGFNG"
+        assert tcr.cdr2a_sequence == "VVLDGL"
+        assert tcr.junction_a_sequence == "CATQYF"
+        assert tcr.cdr1b_sequence == "NSQYPW"
+        assert tcr.cdr2b_sequence == "LRSPGD"
+        assert tcr.junction_b_sequence == "CASQYF"
 
         with pytest.raises(exception.BadV):
             tcr = schema.make_tcr_from_components(


### PR DESCRIPTION
- Fix but that after setting musmusculus mode, the AA sequence querying mechanism used to fetch the V gene CDR1/2 data was still using homosapiens queries