### PR TITLE
Fix unknown residue tokenisation

### DIFF
--- a/src/libtcrlm/tokeniser/cdr3_tokeniser.py
+++ b/src/libtcrlm/tokeniser/cdr3_tokeniser.py
@@ -42,7 +42,7 @@ class Cdr3Tokeniser(Tokeniser):
         if aa_sequence is None:
             return []
 
-        token_indices = [AminoAcidTokenIndex[aa] for aa in aa_sequence]
+        token_indices = [AminoAcidTokenIndex.from_aa_char(aa) for aa in aa_sequence]
         token_positions = [idx for idx, _ in enumerate(aa_sequence, start=1)]
         cdr_length = [len(aa_sequence) for _ in aa_sequence]
         compartment_index = [cdr_index for _ in aa_sequence]
@@ -87,7 +87,7 @@ class BetaCdr3Tokeniser(Tokeniser):
         if aa_sequence is None:
             return []
 
-        token_indices = [AminoAcidTokenIndex[aa] for aa in aa_sequence]
+        token_indices = [AminoAcidTokenIndex.from_aa_char(aa) for aa in aa_sequence]
         token_positions = [idx for idx, _ in enumerate(aa_sequence, start=1)]
         cdr_length = [len(aa_sequence) for _ in aa_sequence]
 

--- a/src/libtcrlm/tokeniser/cdr_tokeniser.py
+++ b/src/libtcrlm/tokeniser/cdr_tokeniser.py
@@ -70,7 +70,11 @@ class CdrTokeniser(Tokeniser):
             token_indices, token_positions, cdr_length, compartment_index
         )
 
-        return list(iterator_over_token_vectors)
+        return [
+            vec
+            for vec in iterator_over_token_vectors
+            if vec[0] != AminoAcidTokenIndex.NULL
+        ]
 
 
 class AlphaCdrTokeniser(Tokeniser):
@@ -126,7 +130,11 @@ class AlphaCdrTokeniser(Tokeniser):
             token_indices, token_positions, cdr_length, compartment_index
         )
 
-        return list(iterator_over_token_vectors)
+        return [
+            vec
+            for vec in iterator_over_token_vectors
+            if vec[0] != AminoAcidTokenIndex.NULL
+        ]
 
 
 class BetaCdrTokeniser(Tokeniser):
@@ -182,4 +190,8 @@ class BetaCdrTokeniser(Tokeniser):
             token_indices, token_positions, cdr_length, compartment_index
         )
 
-        return list(iterator_over_token_vectors)
+        return [
+            vec
+            for vec in iterator_over_token_vectors
+            if vec[0] != AminoAcidTokenIndex.NULL
+        ]

--- a/src/libtcrlm/tokeniser/cdr_tokeniser.py
+++ b/src/libtcrlm/tokeniser/cdr_tokeniser.py
@@ -61,7 +61,7 @@ class CdrTokeniser(Tokeniser):
         if aa_sequence is None:
             return []
 
-        token_indices = [AminoAcidTokenIndex[aa] for aa in aa_sequence]
+        token_indices = [AminoAcidTokenIndex.from_aa_char(aa) for aa in aa_sequence]
         token_positions = [idx for idx, _ in enumerate(aa_sequence, start=1)]
         cdr_length = [len(aa_sequence) for _ in aa_sequence]
         compartment_index = [cdr_index for _ in aa_sequence]
@@ -117,7 +117,7 @@ class AlphaCdrTokeniser(Tokeniser):
         if aa_sequence is None:
             return []
 
-        token_indices = [AminoAcidTokenIndex[aa] for aa in aa_sequence]
+        token_indices = [AminoAcidTokenIndex.from_aa_char(aa) for aa in aa_sequence]
         token_positions = [idx for idx, _ in enumerate(aa_sequence, start=1)]
         cdr_length = [len(aa_sequence) for _ in aa_sequence]
         compartment_index = [cdr_index for _ in aa_sequence]
@@ -173,7 +173,7 @@ class BetaCdrTokeniser(Tokeniser):
         if aa_sequence is None:
             return []
 
-        token_indices = [AminoAcidTokenIndex[aa] for aa in aa_sequence]
+        token_indices = [AminoAcidTokenIndex.from_aa_char(aa) for aa in aa_sequence]
         token_positions = [idx for idx, _ in enumerate(aa_sequence, start=1)]
         cdr_length = [len(aa_sequence) for _ in aa_sequence]
         compartment_index = [cdr_index for _ in aa_sequence]

--- a/src/libtcrlm/tokeniser/token_indices.py
+++ b/src/libtcrlm/tokeniser/token_indices.py
@@ -32,6 +32,12 @@ class AminoAcidTokenIndex(IntEnum):
     W = 21
     Y = 22
 
+    @classmethod
+    def from_aa_char(cls, key: str) -> int:
+        if key == "*":
+            return cls.NULL
+        return cls[key]
+
 
 class Cdr3CompartmentIndex(IntEnum):
     NULL = DefaultTokenIndex.NULL

--- a/tests/test_tokenisers.py
+++ b/tests/test_tokenisers.py
@@ -46,50 +46,99 @@ class TestBetaCdr3Tokeniser:
             self.tokeniser.tokenise(tcr_with_empty_beta)
 
 
-def test_cdr_tokeniser(mock_tcr):
-    tokenised_tcr = CdrTokeniser().tokenise(mock_tcr)
-    expected = torch.tensor(
-        [
-            [2, 0, 0, 0],
-            [19, 1, 6, 1],
-            [18, 2, 6, 1],
-            [8, 3, 6, 1],
-            [7, 4, 6, 1],
-            [22, 5, 6, 1],
-            [8, 6, 6, 1],
-            [14, 1, 6, 2],
-            [3, 2, 6, 2],
-            [12, 3, 6, 2],
-            [5, 4, 6, 2],
-            [8, 5, 6, 2],
-            [12, 6, 6, 2],
-            [4, 1, 6, 3],
-            [3, 2, 6, 3],
-            [19, 3, 6, 3],
-            [16, 4, 6, 3],
-            [22, 5, 6, 3],
-            [7, 6, 6, 3],
-            [18, 1, 5, 4],
-            [14, 2, 5, 4],
-            [9, 3, 5, 4],
-            [12, 4, 5, 4],
-            [22, 5, 5, 4],
-            [7, 1, 6, 5],
-            [22, 2, 6, 5],
-            [14, 3, 6, 5],
-            [14, 4, 6, 5],
-            [6, 5, 6, 5],
-            [10, 6, 6, 5],
-            [4, 1, 6, 6],
-            [3, 2, 6, 6],
-            [18, 3, 6, 6],
-            [16, 4, 6, 6],
-            [22, 5, 6, 6],
-            [7, 6, 6, 6],
-        ]
-    )
+class TestCdrTokeniser:
+    tokeniser = CdrTokeniser()
 
-    assert torch.equal(tokenised_tcr, expected)
+    def test_tokenise(self, mock_tcr):
+        tokenised_tcr = self.tokeniser.tokenise(mock_tcr)
+        expected = torch.tensor(
+            [
+                [2, 0, 0, 0],
+                [19, 1, 6, 1],
+                [18, 2, 6, 1],
+                [8, 3, 6, 1],
+                [7, 4, 6, 1],
+                [22, 5, 6, 1],
+                [8, 6, 6, 1],
+                [14, 1, 6, 2],
+                [3, 2, 6, 2],
+                [12, 3, 6, 2],
+                [5, 4, 6, 2],
+                [8, 5, 6, 2],
+                [12, 6, 6, 2],
+                [4, 1, 6, 3],
+                [3, 2, 6, 3],
+                [19, 3, 6, 3],
+                [16, 4, 6, 3],
+                [22, 5, 6, 3],
+                [7, 6, 6, 3],
+                [18, 1, 5, 4],
+                [14, 2, 5, 4],
+                [9, 3, 5, 4],
+                [12, 4, 5, 4],
+                [22, 5, 5, 4],
+                [7, 1, 6, 5],
+                [22, 2, 6, 5],
+                [14, 3, 6, 5],
+                [14, 4, 6, 5],
+                [6, 5, 6, 5],
+                [10, 6, 6, 5],
+                [4, 1, 6, 6],
+                [3, 2, 6, 6],
+                [18, 3, 6, 6],
+                [16, 4, 6, 6],
+                [22, 5, 6, 6],
+                [7, 6, 6, 6],
+            ]
+        )
+
+        assert torch.equal(tokenised_tcr, expected)
+
+    def test_tokenise_tcr_with_unknown_residue(self):
+        tcr_with_unknown_residue = schema.make_tcr_from_components(
+            "TRAV23/DV6*02", "CATQYF", "TRBV2*01", "CASQYF"
+        )
+
+        tokenised_tcr = self.tokeniser.tokenise(tcr_with_unknown_residue)
+        expected = torch.tensor(
+            [
+                [2, 0, 0, 0],
+                [14, 1, 6, 1],
+                [19, 2, 6, 1],
+                [3, 3, 6, 1],
+                [7, 4, 6, 1],
+                [5, 5, 6, 1],
+                [22, 6, 6, 1],
+                [16, 1, 4, 2],
+                [13, 2, 4, 2],
+                [20, 4, 4, 2],
+                [4, 1, 6, 3],
+                [3, 2, 6, 3],
+                [19, 3, 6, 3],
+                [16, 4, 6, 3],
+                [22, 5, 6, 3],
+                [7, 6, 6, 3],
+                [18, 1, 5, 4],
+                [14, 2, 5, 4],
+                [9, 3, 5, 4],
+                [12, 4, 5, 4],
+                [22, 5, 5, 4],
+                [7, 1, 6, 5],
+                [22, 2, 6, 5],
+                [14, 3, 6, 5],
+                [14, 4, 6, 5],
+                [6, 5, 6, 5],
+                [10, 6, 6, 5],
+                [4, 1, 6, 6],
+                [3, 2, 6, 6],
+                [18, 3, 6, 6],
+                [16, 4, 6, 6],
+                [22, 5, 6, 6],
+                [7, 6, 6, 6],
+            ]
+        )
+
+        assert torch.equal(tokenised_tcr, expected)
 
 
 class TestBetaCdrTokeniser:
@@ -122,10 +171,79 @@ class TestBetaCdrTokeniser:
 
         assert torch.equal(tokenised_tcr, expected)
 
-    def test_tokenise_tcr_with_empty_beta_junction(self):
+    def test_tokenise_tcr_with_empty_beta(self):
         tcr_with_empty_beta = schema.make_tcr_from_components(
             "TRAV1-1*01", "CASQYF", None, None
         )
 
         with pytest.raises(RuntimeError):
             self.tokeniser.tokenise(tcr_with_empty_beta)
+
+
+class TestAlphaTokeniser:
+    tokeniser = AlphaCdrTokeniser()
+
+    def test_tokenise(self, mock_tcr):
+        tokenised_tcr = self.tokeniser.tokenise(mock_tcr)
+        expected = torch.tensor(
+            [
+                [2, 0, 0, 0],
+                [19, 1, 6, 1],
+                [18, 2, 6, 1],
+                [8, 3, 6, 1],
+                [7, 4, 6, 1],
+                [22, 5, 6, 1],
+                [8, 6, 6, 1],
+                [14, 1, 6, 2],
+                [3, 2, 6, 2],
+                [12, 3, 6, 2],
+                [5, 4, 6, 2],
+                [8, 5, 6, 2],
+                [12, 6, 6, 2],
+                [4, 1, 6, 3],
+                [3, 2, 6, 3],
+                [19, 3, 6, 3],
+                [16, 4, 6, 3],
+                [22, 5, 6, 3],
+                [7, 6, 6, 3],
+            ]
+        )
+
+        assert torch.equal(tokenised_tcr, expected)
+
+    def test_tokenise_tcr_with_empty_alpha(self):
+        tcr_with_empty_alpha = schema.make_tcr_from_components(
+            None, None, "TRBV2*01", "CASQYF"
+        )
+
+        with pytest.raises(RuntimeError):
+            self.tokeniser.tokenise(tcr_with_empty_alpha)
+
+    def test_tokenise_tcr_with_unknown_residue(self):
+        tcr_with_unknown_residue = schema.make_tcr_from_components(
+            "TRAV23/DV6*02", "CATQYF", None, None
+        )
+
+        tokenised_tcr = self.tokeniser.tokenise(tcr_with_unknown_residue)
+        expected = torch.tensor(
+            [
+                [2, 0, 0, 0],
+                [14, 1, 6, 1],
+                [19, 2, 6, 1],
+                [3, 3, 6, 1],
+                [7, 4, 6, 1],
+                [5, 5, 6, 1],
+                [22, 6, 6, 1],
+                [16, 1, 4, 2],
+                [13, 2, 4, 2],
+                [20, 4, 4, 2],
+                [4, 1, 6, 3],
+                [3, 2, 6, 3],
+                [19, 3, 6, 3],
+                [16, 4, 6, 3],
+                [22, 5, 6, 3],
+                [7, 6, 6, 3],
+            ]
+        )
+
+        assert torch.equal(tokenised_tcr, expected)

--- a/tests/test_tokenisers.py
+++ b/tests/test_tokenisers.py
@@ -2,6 +2,20 @@ import pytest
 import torch
 from libtcrlm import schema
 from libtcrlm.tokeniser import *
+from libtcrlm.tokeniser.token_indices import AminoAcidTokenIndex
+
+
+@pytest.mark.parametrize(
+    argnames=("key", "expected"),
+    argvalues=(
+        ("A", 3),
+        ("C", 4),
+        ("*", 0),
+    ),
+)
+def test_custom_indexer(key, expected):
+    val = AminoAcidTokenIndex.from_aa_char(key)
+    assert val == expected
 
 
 class TestBetaCdr3Tokeniser:


### PR DESCRIPTION
Closes #19 by handling cases where the germline sequences of certain TR alleles contain unknown residues (encoded as `*`). These residues are explicitly excluded in the tokenisation, while the numbering of the reisdues are kept unchanged so that the models can focus on the correct available information.